### PR TITLE
Fix typo in lab instructions

### DIFF
--- a/Instructions/Labs/01-identify-compatibility-issues.md
+++ b/Instructions/Labs/01-identify-compatibility-issues.md
@@ -53,7 +53,7 @@ ALTER TABLE [SalesLT].[Customer] ADD [Next] VARCHAR(5);
 
 Follow these steps to install the migration extension. If Azure migration extension is already installed, you can skip these steps.
 
-1. Open the extensions manager in Azure Data Studio. s
+1. Open the extensions manager in Azure Data Studio.
 
 1. Search for ***Azure SQL Migration***, and install the extension. Once you install it, the Azure SQL Migration extension is in the list of installed extensions.
 


### PR DESCRIPTION
There was an extra 's' after the end of the sentence in the lab instructions.
